### PR TITLE
Нормально работающая локализация

### DIFF
--- a/Pages/Shared/Components/LevelsTable.razor
+++ b/Pages/Shared/Components/LevelsTable.razor
@@ -56,7 +56,7 @@
         {
             <tr>
                 <td class="p-1">@level.LevelId.ToString()</td>
-                <td class="p-1">@(DateTime.UnixEpoch.AddSeconds(level.RequestTime).ToString("dd.MM.yyyy, HH:mm"))</td>
+                <td class="p-1">@(DateTime.UnixEpoch.AddSeconds(level.RequestTime).ToString())</td>
                 @if (CanDeleteLevels)
                 {
                     <td class="p-1 text-danger text-center"><a class="text-danger" href="/Delete?levelId=@level.LevelId&redirect=@PageName">X</a></td>

--- a/Startup.cs
+++ b/Startup.cs
@@ -25,7 +25,9 @@ namespace GDLevels
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            
+            services.Configure<RequestLocalizationOptions>(options => options
+            .SetDefaultCulture("ru-RU")
+            .AddSupportedCultures("ru-RU", "ru", "en", "en-US", "en-GB"));
             services.AddDistributedMemoryCache();
             services.AddSession(options =>
             {
@@ -47,6 +49,7 @@ namespace GDLevels
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseHttpLogging();
             }
             else
             {
@@ -59,7 +62,7 @@ namespace GDLevels
             {
                 ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
             });
-
+            app.UseRequestLocalization();
             app.UseAuthentication();
             //app.UseHttpsRedirection();
             app.UseStaticFiles();


### PR DESCRIPTION
Теперь вместо захардкоженого формата для даты добавления уровня
используется формат по умолчанию на основе локализации, которая теперь
правильно определяется, но их крупных всего пока две - русская и английская разных вариаций